### PR TITLE
Rebrand site as Cai Tuo blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,23 @@
-![preview Long Haul](/preview.jpg)
+# Cai Tuo Blog
 
-Long Haul is a minimal jekyll theme built with SASS and focuses on long form blog posts. It is meant to be used as a starting point for a jekyll blog/website.
+This repository contains the source for the **Cai Tuo Blog**, a Jekyll-powered site that collects long-form notes on software engineering, creative work, and life in the mountains.
 
-If you really enjoy Long Haul and want to give me credit somewhere on the internet send or tweet out your experience with Long Haul and tag me [@brianmaierjr](https://twitter.com/brianmaierjr).
+## Local development
 
-#### [View Demo](http://brianmaierjr.com/long-haul)
+To work with the project locally:
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/bd29f13b-3754-46d7-9a39-48db2e174b99/deploy-status)](https://app.netlify.com/sites/long-haul/deploys)
+1. Install [Ruby](https://www.ruby-lang.org/) and [Bundler](https://bundler.io/).
+2. Install dependencies:
+   ```bash
+   bundle install
+   ```
+3. Build and serve the site with live reload:
+   ```bash
+   bundle exec jekyll serve
+   ```
 
-## Features
+The generated site will be available at `http://localhost:4000`.
 
--   Minimal, Type Focused Design
--   Built with SASS
--   SVG Social Icons
--   Responsive Nav Menu
--   XML Feed for RSS Readers
--   Contact Form via Formspree
--   5 Post Loop with excerpt on Home Page
--   Previous / Next Post Navigation
--   Estimated Reading Time for posts
--   Stylish Drop Cap on posts
--   A Better Type Scale for all devices
--   Comments powered by Disqus
--   [Dark Mode support](https://github.com/brianmaierjr/long-haul/blob/master/preview-dark.png) via [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+## Licensing
 
-## Setup
-
-1. [Install Jekyll](http://jekyllrb.com)
-2. Fork the [Long Haul repo](http://github.com/brianmaierjr/long-haul)
-3. Clone it
-4. [Install Bundler](http://bundler.io/)
-5. Run `bundle install`
-6. Run Jekyll Serve and Watch command`bundle exec jekyll serve -w`
-
-## Site Settings
-
-The main settings can be found inside the `_config.yml` file:
-
--   **title:** title of your site
--   **description:** description of your site
--   **url:** your url
--   **paginate:** the amount of posts displayed on homepage
--   **navigation:** these are the links in the main site navigation
--   **social** diverse social media usernames (optional)
--   **google_analytics** Google Analytics key (optional)
-
-### Header Option
-
-If you'd like your header to be larger then you can use the option below in you `config.yml` to make it take up half of the vertical space on screens 800px wide and up. _Preview image below._
-
--   **header:** large
-
-![preview Long Haul](/preview-large.png)
-
-## To use on GitHub Pages
-
-To use latest Jekyll and Jekyll Sass Converter on GitHub Pages, <a href="https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/">you can now deploy to a GitHub Pages site using GitHub Actions.</a>
-
-## License
-
-This is [MIT](LICENSE) with no added caveats, so feel free to use this Jekyll theme on your site without linking back to me or using a disclaimer.
+Content is © Cai Tuo. The underlying Jekyll theme remains open source under the MIT License.

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
-title: Long Haul
-description: Long Form Jekyll theme built with SASS
+title: Cai Tuo Blog
+description: Reflections on software engineering, creativity, and life in the mountains.
 
-url: https://long-haul.netlify.app
+url: https://caituoblog.com
 # Only necessary when hosting your site in a sub-directory. Project sites hosted on GitHub Pages are the common use-case of this variable.
 baseurl: # Ex: /project-page
 paginate_path: "blog/page:num/"
@@ -19,23 +19,25 @@ plugins: [jekyll-paginate]
 paginate: 5
 
 navigation:
-    - title: Home
-      url: /index.html
+    - title: Blog
+      url: /
     - title: About
       url: /about
+    - title: Archive
+      url: /articles
     - title: Contact
       url: /contact
 
 social:
-    github: brianmaierjr
-    twitter: brianmaierjr
-    facebook: brianmaierjr
-    email: brimaidesigns@gmail.com
-    linkedin: brianmaierjr
-    youtube: RickAstleyYT
-    tumblr: i-am-a-fish
+    github: caituo27
+    twitter: caituowrites
+    facebook: caituoblog
+    email: hello@caituoblog.com
+    linkedin: cai-tuo
+    youtube: caituostudio
+    tumblr: caituoblog
 
 google_analytics: "UA-58263416-1"
 
 disqus:
-    shortname: brianmaierjr
+    shortname:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,9 @@
 <div class="footer">
 	<div class="container">
 		<p class="copy">
-			&copy; {{ site.time | date: '%Y' }}
-			<a href="http://brianmaierjr.com">Brian Maier Jr.</a> Powered by
-			<a href="http://jekyllrb.com">Jekyll</a>
+                        &copy; {{ site.time | date: '%Y' }}
+                        <span>Cai Tuo</span> · Powered by
+                        <a href="https://jekyllrb.com">Jekyll</a>
 		</p>
 
 		<div class="footer-links">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,10 +33,10 @@
 		property="og:image"
 	/>
 	{%- else -%}
-	<meta
-		content="{{ '/assets/img/touring.jpg' | absolute_url }}"
-		property="og:image"
-	/>
+        <meta
+                content="{{ '/assets/img/snow-mountain.svg' | absolute_url }}"
+                property="og:image"
+        />
 	{%- endif -%}
 
 	<!-- Twitter Cards -->
@@ -59,14 +59,14 @@
 		content="{{ '/assets/img/' | append:page.image | absolute_url }}"
 	/>
 	{%- else -%}
-	<meta
-		name="twitter:image:src"
-		content="{{ '/assets/img/touring.jpg' | absolute_url }}"
-	/>
+        <meta
+                name="twitter:image:src"
+                content="{{ '/assets/img/snow-mountain.svg' | absolute_url }}"
+        />
 	{%- endif -%}
 
 	<!-- Favicon -->
-	<link rel="icon" type="image/x-icon" href="{{/assets/img/favicon.ico | relative_url }}"/>
+        <link rel="icon" type="image/x-icon" href="{{ '/assets/img/favicon.ico' | relative_url }}" />
 
 	<!-- Come and get me RSS readers -->
 	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,8 +8,7 @@
                      <a href="{{ link.url | relative_url }}">{{ link.title }}</a>
                  </li>
                  {%- endfor -%}
-                 <li> <a href="https://github.com/brianmaierjr/long-haul" target="_blank">GitHub</a></li>
-                 <li><a href="https://github.com/brianmaierjr/long-haul/archive/master.zip">Download Theme</a></li>
+                <li><a href="{{ '/feed.xml' | relative_url }}">RSS</a></li>
              </ul>
          </nav>
      </div>

--- a/_posts/2014-12-11-image-in-post.markdown
+++ b/_posts/2014-12-11-image-in-post.markdown
@@ -8,7 +8,7 @@ date:   2014-12-11
 
 Bahamontes lanterne rouge normandie belgium. Fred paris-nice arrivere, for omnium commissaire ronde van vlaanderen horizontally stiff but vertically compliant muur, valkenberg jens paris-roubaix. Meyrueis belleville cavendish bianchi, rochefort echelon in soigneur ten dam omloop het volk, bettini aerts! Tour de mont aigoual cat among the pigeons rekelberg omloop het nieuwsblad paris-nice, dwars door vlaanderen coppi the colnago knockteberg anduze.
 
-<img src="/assets/img/touring.jpg" alt=""> 
+<img src="/assets/img/snow-mountain.svg" alt=""> 
 
 Kaperij lanterne rouge musette rund um koln bruges thor smash, geraardsbergen riis petacchi molteni pedaling squares. Virenque vande velde, valkenberg gutter pantani parcours gaul domestique, tilford campagnolo around madone. Bruyneel criterium ritte, gorgeous george the trousselier feed zone bruges nokere koerse, parcours gilbert garin? Anquetil valkenberg bettini cat among the pigeons.
 

--- a/_posts/2014-12-12-figure-with-caption.markdown
+++ b/_posts/2014-12-12-figure-with-caption.markdown
@@ -10,13 +10,13 @@ date:   2014-12-12
 Bahamontes lanterne rouge normandie belgium. Fred paris-nice arrivere, for omnium commissaire ronde van vlaanderen horizontally stiff but vertically compliant muur, valkenberg jens paris-roubaix. Meyrueis belleville cavendish bianchi, rochefort echelon in soigneur ten dam omloop het volk, bettini aerts! Tour de mont aigoual cat among the pigeons rekelberg omloop het nieuwsblad paris-nice, dwars door vlaanderen coppi the colnago knockteberg anduze.
 
 <figure>
-	<img src="/assets/img/touring.jpg" alt=""> 
+	<img src="/assets/img/snow-mountain.svg" alt=""> 
 	<figcaption>Fig1. - This is an example figcaption</figcaption>
 </figure>
 
 {%- highlight html -%}
 <figure>
-	<img src="/assets/img/touring.jpg" alt=""> 
+	<img src="/assets/img/snow-mountain.svg" alt=""> 
 	<figcaption>Fig1. - This is an example figcaption</figcaption>
 </figure>
 {%- endhighlight -%}

--- a/_posts/2014-12-14-featured-image.markdown
+++ b/_posts/2014-12-14-featured-image.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Featured Image"
 date:   2014-12-14
-image: touring.jpg
+image: snow-mountain.svg
 ---
 
 <p class="intro"><span class="dropcap">L</span>orem ipsum thor smash liege-bastogne-liege landbouwkrediet ombregt krabbe, rouleur derby is for lovers bonk giro gilbert bidon. Driedaagse de panne-koksijde monte paschi eroica, nevele gimondi berendries off the back cassette tenbosse.</p>

--- a/_sass/breakpoints/_mobileup.scss
+++ b/_sass/breakpoints/_mobileup.scss
@@ -181,7 +181,7 @@ HEADER STYLING
 
 .header {
 	background-color: $background-color;
-	background-image: url("../img/touring.jpg");
+    background-image: url("../img/snow-mountain.svg");
 	background-size: cover;
 	background-position: center center;
 	color: white;

--- a/about.md
+++ b/about.md
@@ -1,24 +1,12 @@
 ---
 layout: default
-title: About Long Haul
+title: About Cai Tuo
 ---
 
 <div class="post">
-	<h1 class="pageTitle">About Long Haul</h1>
-	<img src="{{ '/assets/img/touring.jpg' | relative_url }}" alt="">
-	<p class="intro">Long Haul is a minimal, long form <a href="http://jekyllrb.com">Jekyll</a> Theme. It can be used as is or customized to your hearts desire.</p>
-	<p>Long Haul was created in honor of all the hard working touring bicycles that have traversed the globe time and time again. Take it for a spin.</p>
-	<h2>Features</h2>
-	<ul>
-		<li>Built with the <a href="https://github.com/jekyll/jekyll-sass-converter">Jekyll SASS convertor</a> plugin</li>
-  		<li>SVG Social Icons from <a href="http://customizr.net/icons/">Customizr</a></li>
-  		<li><a href="http://responsive-nav.com/">Responsive Nav Menu</a></li>
-  		<li><a href="https://github.com/snaptortoise/jekyll-rss-feeds">XML Feed for RSS Readers</a></li>
-  		<li>Contact Form via <a href="http://formspree.io/">Formspree</a></li>
-      <li>5 Post Loop with excerpt on Home Page</li>
-  		<li>Previous / Next Post Navigation</li>
-      <li>Estimated Reading Time for posts</li>
-  		<li><a href="https://github.com/adobe-webplatform/dropcap.js">Drop Cap</a> on posts</li>
-  		<li><a href="http://typecast.com/blog/a-more-modern-scale-for-web-typography">A Better Type Scale</a></li>
-  	</ul>
+  <h1 class="pageTitle">About Cai Tuo</h1>
+  <img src="{{ '/assets/img/snow-mountain.svg' | relative_url }}" alt="Illustrated snow-capped mountains under a blue sky" />
+  <p class="intro">Welcome to the corner of the internet where I, Cai Tuo, collect reflections on software, creativity, and the journeys in between.</p>
+  <p>I build products, write about the lessons I learn along the way, and chase the same sense of clarity you get when hiking into crisp alpine air. This blog is a place to share ideas, document experiments, and celebrate the people and landscapes that inspire careful craftsmanship.</p>
+  <p>Expect deep dives into engineering topics, thoughtful notes on personal growth, and the occasional story about adventures in nature. If those themes resonate with you, I am glad you're here—explore the posts, share your thoughts, and let's keep the conversation going.</p>
 </div>

--- a/articles.md
+++ b/articles.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Your New Jekyll Site
+title: Blog Archive
 ---
 
 <div id="articles">
-  <h1>Articles</h1>
+  <h1>Blog Archive</h1>
   <ul class="posts noList">
     {%- for post in site.posts -%}
       <li>

--- a/assets/img/snow-mountain.svg
+++ b/assets/img/snow-mountain.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#5bb7ff" />
+      <stop offset="70%" stop-color="#b8e2ff" />
+      <stop offset="100%" stop-color="#f2f7ff" />
+    </linearGradient>
+    <linearGradient id="mountain1" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#4a5d6a" />
+      <stop offset="100%" stop-color="#2e3f49" />
+    </linearGradient>
+    <linearGradient id="mountain2" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#5e7080" />
+      <stop offset="100%" stop-color="#35434c" />
+    </linearGradient>
+    <linearGradient id="hill" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#3c8a4b" />
+      <stop offset="100%" stop-color="#2c6b38" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#sky)" />
+  <polygon points="-200,900 320,420 800,900" fill="url(#mountain1)" />
+  <polygon points="160,900 720,320 1280,900" fill="url(#mountain2)" />
+  <polygon points="640,900 1120,440 1760,900" fill="url(#mountain1)" opacity="0.8" />
+  <polygon points="250,620 320,420 390,620" fill="#ffffff" opacity="0.9" />
+  <polygon points="690,520 720,320 760,520" fill="#ffffff" opacity="0.9" />
+  <polygon points="1030,600 1120,440 1210,600" fill="#ffffff" opacity="0.9" />
+  <rect y="760" width="1600" height="140" fill="url(#hill)" />
+</svg>

--- a/contact.md
+++ b/contact.md
@@ -1,22 +1,22 @@
 ---
 layout: default
-title: Contact Long Haul
+title: Contact Cai Tuo
 ---
 
 <div id="contact">
-  <h1 class="pageTitle">Contact Me</h1>
+  <h1 class="pageTitle">Contact Cai Tuo</h1>
   <div class="contactContent">
-    <p class="intro">This is an example Contact page. If you want to make changes then do so in the <code>contact.html</code> file.</p>
-    <p>The form is provided by <a href="http://formspree.io/">Formspree.</a> Follow the directions on their site to set up the form for use.</p>
-    <p>If you have questions about the theme feel free to <a href="mailto:brimaidesigns@gmail.com">email me</a> or create an issue on <a href="https://github.com/brianmaierjr/long-haul">GitHub</a>. Enjoy!</p>
+    <p class="intro">Have a question about a post, a collaboration idea, or want to say hello? I'd love to hear from you.</p>
+    <p>Email is the best way to reach me—drop a note to <a href="mailto:hello@caituoblog.com">hello@caituoblog.com</a> and I'll respond as soon as I can. You can also connect through the social links in the footer.</p>
+    <p>If you prefer using a form, fill out the fields below and your message will head straight to my inbox.</p>
   </div>
-  <form action="http://formspree.io/your@mail.com" method="POST">
+  <form action="https://formspree.io/f/your-form-id" method="POST">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" class="full-width"><br>
+    <input type="text" id="name" name="name" class="full-width" />
     <label for="email">Email Address</label>
-    <input type="email" id="email" name="_replyto" class="full-width"><br>
+    <input type="email" id="email" name="_replyto" class="full-width" />
     <label for="message">Message</label>
-    <textarea name="message" id="message" cols="30" rows="10" class="full-width"></textarea><br>
-    <input type="submit" value="Send" class="button">
+    <textarea name="message" id="message" cols="30" rows="10" class="full-width"></textarea>
+    <input type="submit" value="Send" class="button" />
   </form>
 </div>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Long Haul
+title: Cai Tuo Blog
 ---
 
 <div class="home" id="home">
-	<h1 class="pageTitle">Recent Posts</h1>
+        <h1 class="pageTitle">Latest from the Blog</h1>
 	<div class="posts noList">
 		{%- for post in paginator.posts -%}
 		<article>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Brian Maier Jr.",
+  "author": "Cai Tuo",
   "license": "MIT",
   "devDependencies": {
     "browser-sync": "^3.0.2",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/brianmaierjr/long-haul.git"
+    "url": "https://github.com/caituo27/caituo27.github.io.git"
   },
   "keywords": [
     "jekyll",


### PR DESCRIPTION
## Summary
- replace the cycling-themed hero and post imagery with a new snow mountain illustration and update metadata to use it by default
- rebrand navigation, content pages, and configuration so the site presents itself as the Cai Tuo Blog
- refresh supporting metadata and documentation, including the footer, package information, and README

## Testing
- `bundle install` *(fails: Bundler cannot reach rubygems.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce53ee92e4832b9616c8849ed0a27b