### PR TITLE
Hide archive and RSS navigation items

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,8 +23,6 @@ navigation:
       url: /
     - title: About
       url: /about
-    - title: Archive
-      url: /articles
     - title: Contact
       url: /contact
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,6 @@
                      <a href="{{ link.url | relative_url }}">{{ link.title }}</a>
                  </li>
                  {%- endfor -%}
-                <li><a href="{{ '/feed.xml' | relative_url }}">RSS</a></li>
              </ul>
          </nav>
      </div>


### PR DESCRIPTION
## Summary
- remove the Archive navigation item from the global navigation configuration
- drop the RSS link from the header include so it no longer renders across pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce57594e50832b8502a2ed086d145f