### PR TITLE
Update footer social links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,11 +28,11 @@ navigation:
 
 social:
     github: caituo27
-    twitter: caituowrites
+    twitter: mcdhdm
     facebook:
     email:
     linkedin:
-    youtube: caituostudio
+    youtube:
     tumblr:
 
 google_analytics: "UA-58263416-1"

--- a/_includes/footer_links/github_icon.html
+++ b/_includes/footer_links/github_icon.html
@@ -1,5 +1,5 @@
 <li>
-	<a href="https://github.com/{{ site.social.github }}" target="_blank">
+        <a href="https://github.com/caituo27" target="_blank">
 		<svg
 			id="github"
 			class="custom-icon"

--- a/_includes/footer_links/twitter_icon.html
+++ b/_includes/footer_links/twitter_icon.html
@@ -1,25 +1,25 @@
 <li>
-        <a href="https://twitter.com/{{ site.social.twitter }}" target="_blank">
+        <a href="https://x.com/{{ site.social.twitter }}" target="_blank">
                 <svg
-                        id="twitter"
+                        id="x"
                         class="custom-icon"
                         version="1.1"
-			xmlns="http://www.w3.org/2000/svg"
-			xmlns:xlink="http://www.w3.org/1999/xlink"
-			viewBox="0 0 100 100"
-			style="height: 30px; width: 30px;"
-		>
-			<circle
-				class="outer-shape"
-				cx="50"
-				cy="50"
-				r="48"
-				style="opacity: 1;"
-			></circle>
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        viewBox="0 0 24 24"
+                        style="height: 30px; width: 30px;"
+                >
+                        <circle
+                                class="outer-shape"
+                                cx="12"
+                                cy="12"
+                                r="11"
+                                style="opacity: 1;"
+                        ></circle>
                         <path
                                 class="inner-shape"
                                 style="opacity: 1;"
-                                d="M68.284 21.716L50 40 31.716 21.716 21.716 31.716 40 50 21.716 68.284 31.716 78.284 50 60 68.284 78.284 78.284 68.284 60 50 78.284 31.716z"
+                                d="M18.244 2.25h3.31l-7.218 8.26L22 21.75h-6.093l-4.78-6.241-5.47 6.241H2.344l7.43-8.488L2 2.25h6.216l4.3 5.572 5.728-5.572z"
                         ></path>
                 </svg>
         </a>


### PR DESCRIPTION
## Summary
- update the footer X link to point at the new profile and render the official X icon inside the existing button styling
- point the GitHub footer icon directly at the caituo27 profile
- remove the configured YouTube handle so the icon no longer renders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce5bc71c08832bafb58ae4bf6246c4