### PR TITLE
Reduce footer X icon size

### DIFF
--- a/_includes/footer_links/twitter_icon.html
+++ b/_includes/footer_links/twitter_icon.html
@@ -7,7 +7,7 @@
                         xmlns="http://www.w3.org/2000/svg"
                         xmlns:xlink="http://www.w3.org/1999/xlink"
                         viewBox="0 0 24 24"
-                        style="height: 30px; width: 30px;"
+                        style="height: 15px; width: 15px;"
                 >
                         <circle
                                 class="outer-shape"


### PR DESCRIPTION
## Summary
- shrink the footer X icon by reducing its inline SVG dimensions to half the original size

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000 *(fails: jekyll executable missing because bundle install cannot reach rubygems.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce63567e10832b93041aa6024d3115