### PR TITLE
Reorder navigation menu items

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,10 +19,10 @@ plugins: [jekyll-paginate]
 paginate: 5
 
 navigation:
-    - title: Blog
-      url: /
     - title: About
       url: /about
+    - title: Blog
+      url: /
     - title: Contact
       url: /contact
 


### PR DESCRIPTION
## Summary
- reorder the navigation configuration so the menu reads About, Blog, Contact on the homepage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce71812db8832b8759a2b3545377f0