### PR TITLE
Add animated logo spread effect

### DIFF
--- a/_sass/breakpoints/_800up.scss
+++ b/_sass/breakpoints/_800up.scss
@@ -71,12 +71,20 @@ HEADER STYLING
 		overflow: hidden;
 	}
 
-	h1 {
-		font-size: 3em;
-		line-height: 1;
-		letter-spacing: -3px;
-		padding-left: 0;
-	}
+        h1 {
+                font-size: 3em;
+                line-height: 1;
+                letter-spacing: -3px;
+                padding-left: 0;
+
+                .logo__char {
+                        margin-right: -3px;
+
+                        &:last-child {
+                                margin-right: 0;
+                        }
+                }
+        }
 
 	nav {
 		float: left;

--- a/_sass/breakpoints/_mobileup.scss
+++ b/_sass/breakpoints/_mobileup.scss
@@ -180,10 +180,10 @@ HEADER STYLING
 ***************/
 
 .header {
-	background-color: $background-color;
+        background-color: $background-color;
     background-image: url("../img/snow-mountain.svg");
-	background-size: cover;
-	background-position: center center;
+        background-size: cover;
+        background-position: center center;
 	color: white;
 	padding: 0;
 	height: 3em;
@@ -206,8 +206,41 @@ HEADER STYLING
 		a {
 			color: white;
 			text-decoration: none;
-		}
-	}
+                }
+        }
+}
+
+.logo {
+        a {
+                display: inline-block;
+                position: relative;
+                overflow: visible;
+                white-space: nowrap;
+        }
+}
+
+.logo__char {
+        display: inline-block;
+        transition: transform 0.65s cubic-bezier(0.4, 0, 0.2, 1);
+        will-change: transform;
+}
+
+.logo a.logo--animating .logo__char {
+        animation: logo-spread 0.9s ease-in-out;
+}
+
+@keyframes logo-spread {
+        0% {
+                transform: translateX(0);
+        }
+
+        45% {
+                transform: translateX(calc(var(--char-offset, 0) * 0.8rem));
+        }
+
+        100% {
+                transform: translateX(0);
+        }
 }
 
 /***************

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -5,13 +5,124 @@ $( document ).ready(function() {
 	var dropcaps = document.querySelectorAll(".dropcap");
 	window.Dropcap.layout(dropcaps, 2);
 
-	// Responsive-Nav
-	var nav = responsiveNav(".nav-collapse");
+        // Responsive-Nav
+        var nav = responsiveNav(".nav-collapse");
 
-	// Round Reading Time
-    $(".time").text(function (index, value) {
-      return Math.round(parseFloat(value));
-    });
+        // Round Reading Time
+        $(".time").text(function (index, value) {
+                return Math.round(parseFloat(value));
+        });
+
+        // Logo animation effect
+        (function () {
+                var $logoLinks = $(".logo a");
+
+                if (!$logoLinks.length) {
+                        return;
+                }
+
+                var animationDuration = 900;
+
+                $logoLinks.each(function () {
+                        var $link = $(this);
+                        var originalText = $.trim($link.text());
+
+                        if (!originalText) {
+                                return;
+                        }
+
+                        var characters = originalText.split("");
+                        var totalChars = characters.length;
+                        var wrappedHtml = characters
+                                .map(function (char, index) {
+                                        var safeChar = $("<div />").text(char).html();
+                                        var displayChar = char === " " ? "&nbsp;" : safeChar;
+                                        var offset = index - (totalChars - 1) / 2;
+
+                                        return (
+                                                '<span class="logo__char" style="--char-offset:' +
+                                                offset +
+                                                ';">' +
+                                                displayChar +
+                                                "</span>"
+                                        );
+                                })
+                                .join("");
+
+                        $link
+                                .attr("aria-label", originalText)
+                                .attr("data-logo-text", originalText)
+                                .html(wrappedHtml);
+
+                        var isAnimating = false;
+
+                        $link.on("click", function (event) {
+                                if (
+                                        event.metaKey ||
+                                        event.ctrlKey ||
+                                        event.shiftKey ||
+                                        event.altKey ||
+                                        (typeof event.which === "number" && event.which !== 1)
+                                ) {
+                                        return;
+                                }
+
+                                event.preventDefault();
+
+                                if (isAnimating) {
+                                        return;
+                                }
+
+                                var href = $link.attr("href");
+                                var absoluteHref = "";
+
+                                if (href && href !== "#") {
+                                        absoluteHref = resolveHref(href);
+                                }
+
+                                isAnimating = true;
+
+                                $link.removeClass("logo--animating");
+                                // Force reflow so the animation can restart when the class is re-applied
+                                void this.offsetWidth;
+                                $link.addClass("logo--animating");
+
+                                window.setTimeout(
+                                        function () {
+                                                $link.removeClass("logo--animating");
+                                                isAnimating = false;
+
+                                                if (absoluteHref && !isSamePage(absoluteHref)) {
+                                                        window.location.href = absoluteHref;
+                                                }
+                                        },
+                                        animationDuration
+                                );
+                        });
+                });
+
+                function resolveHref(href) {
+                        var parser = document.createElement("a");
+                        parser.href = href;
+
+                        return parser.href;
+                }
+
+                function isSamePage(url) {
+                        if (!url) {
+                                return true;
+                        }
+
+                        var parser = document.createElement("a");
+                        parser.href = url;
+
+                        var normalise = function (path) {
+                                return path.replace(/\/+$/, "") || "/";
+                        };
+
+                        return normalise(parser.pathname) === normalise(window.location.pathname);
+                }
+        })();
 
 });
 


### PR DESCRIPTION
## Summary
- wrap the header logo text in animated spans and trigger a parallel spread effect on click
- add supporting styles and keyframes so logo characters fan out and return smoothly
- preserve desktop spacing by offsetting individual logo characters at larger breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0fa94babc832b9de5998d6e88306e